### PR TITLE
Problems with float values and with node resizing

### DIFF
--- a/QGraphViz/Engines/Dot.py
+++ b/QGraphViz/Engines/Dot.py
@@ -35,9 +35,12 @@ class Dot(LayoutEngine):
         if type(n)==Graph:
             for nn in n.nodes:
                 self.process_size(nn)
-        
+
         if("label" in n.kwargs.keys()):
-            if(n.kwargs["label"]!=""):
+            if ("size" in n.kwargs.keys()):
+                width = n.kwargs["size"][0]
+                height = n.kwargs["size"][1]
+            elif(n.kwargs["label"]!=""):
                 rect = self.fm.boundingRect(n.kwargs["label"])
                 width=rect.width()+self.margins[0]
                 height=rect.height()+self.margins[1]
@@ -86,11 +89,11 @@ class Dot(LayoutEngine):
             height = h_ if h_>height else height
             width += 2*self.margins[0]
             height += 2*self.margins[1]
-            
-        
+
+
 
         n.size[0]=width
-        n.size[1]=height        
+        n.size[1]=height
 
     def process(self, n, graph, index=0, nb_brothers=0, depth=0, stage=0):
         n.processed+=1
@@ -140,7 +143,7 @@ class Dot(LayoutEngine):
 
             n.pos[0]=x
             n.pos[1]=y
-                    
+
         for i,oe in enumerate(n.out_edges):
             if oe.dest.processed<20:
                 self.process(oe.dest, graph, i,len(n.out_edges))
@@ -149,12 +152,12 @@ class Dot(LayoutEngine):
             n.depth_x_pos=[0]
             for nn in n.nodes:
                 self.process(nn, n, 0, len(n.nodes), depth=depth)
-            
+
 
     def build_graph(self, graph):
         for n in graph.nodes:
             n.processed=0
-         
+
         for i,n in enumerate(graph.nodes):
             self.process_size(n)
 

--- a/QGraphViz/QGraphViz.py
+++ b/QGraphViz/QGraphViz.py
@@ -573,14 +573,14 @@ class QGraphViz_Core(QWidget):
         gpos = subgraph.global_pos
 
         painter.drawRect(
-                    gpos[0]-subgraph.size[0]/2,
-                    gpos[1]-subgraph.size[1]/2,
+                    int(gpos[0]-subgraph.size[0]/2),
+                    int(gpos[1]-subgraph.size[1]/2),
                     subgraph.size[0], subgraph.size[1])
 
         if("label" in subgraph.kwargs.keys()):
             painter.drawText(
-                gpos[0]-subgraph.size[0]/2,
-                gpos[1]-subgraph.size[1]/2,
+                int(gpos[0]-subgraph.size[0]/2),
+                int(gpos[1]-subgraph.size[1]/2),
                 subgraph.size[0], subgraph.size[1],
                 Qt.AlignCenter|Qt.AlignTop,subgraph.kwargs["label"])
 
@@ -669,17 +669,17 @@ class QGraphViz_Core(QWidget):
                 if("shape" in node.kwargs.keys()):
                     if(node.kwargs["shape"]=="box"):
                         painter.drawRect(
-                                    gpos[0]-node.size[0]/2,
-                                    gpos[1]-node.size[1]/2,
+                                    int(gpos[0]-node.size[0]/2),
+                                    int(gpos[1]-node.size[1]/2),
                                     node.size[0], node.size[1])
 
                     elif(node.kwargs["shape"]=="circle"):
                         painter.drawEllipse(
-                                    gpos[0]-node.size[0]/2,
-                                    gpos[1]-node.size[1]/2,
+                                    int(gpos[0]-node.size[0]/2),
+                                    int(gpos[1]-node.size[1]/2),
                                     node.size[0], node.size[1])
                     elif(node.kwargs["shape"]=="triangle"):
-                        rect = QRect(gpos[0]-node.size[0]/2, gpos[1]-2*node.size[1]/3, node.size[0], node.size[1])
+                        rect = QRect(int(gpos[0]-node.size[0]/2), int(gpos[1]-2*node.size[1]/3), node.size[0], node.size[1])
 
                         path = QPainterPath()
                         path.moveTo(rect.left() + (rect.width() / 2), rect.top())
@@ -690,7 +690,7 @@ class QGraphViz_Core(QWidget):
                         painter.fillPath(path, brush)
                         painter.drawPath(path)
                     elif(node.kwargs["shape"]=="polygon"):
-                        rect = QRect(gpos[0]-node.size[0]/2, gpos[1]-node.size[1]/2, node.size[0], node.size[1])
+                        rect = QRect(int(gpos[0]-node.size[0]/2), int(gpos[1]-node.size[1]/2), node.size[0], node.size[1])
 
                         path = QPainterPath()
                         path.moveTo(rect.left() + (rect.width() / 4), rect.top())
@@ -704,7 +704,7 @@ class QGraphViz_Core(QWidget):
                         painter.fillPath(path, brush)
                         painter.drawPath(path)
                     elif(node.kwargs["shape"]=="diamond"):
-                        rect = QRect(gpos[0]-node.size[0]/2, gpos[1]-node.size[1]/2, node.size[0], node.size[1])
+                        rect = QRect(int(gpos[0]-node.size[0]/2), int(gpos[1]-node.size[1]/2), node.size[0], node.size[1])
 
                         path = QPainterPath()
                         path.moveTo(rect.left() + (rect.width() / 2), rect.top())
@@ -756,15 +756,15 @@ class QGraphViz_Core(QWidget):
                             node.size[1] = height if height>node.size[1] else node.size[1]
                             painter.drawImage(
                                 QRect(
-                                    gpos[0]-node.size[0]/2,
-                                    gpos[1]-node.size[1]/2,
+                                    int(gpos[0]-node.size[0]/2),
+                                    int(gpos[1]-node.size[1]/2),
                                     node.size[0],
                                     node.size[1]), 
                                 image)
                 else:
                     painter.drawEllipse(
-                                gpos[0]-node.size[0]/2,
-                                gpos[1]-node.size[1]/2,
+                                int(gpos[0]-node.size[0]/2),
+                                int(gpos[1]-node.size[1]/2),
                                 node.size[0], node.size[1])
 
 
@@ -782,8 +782,8 @@ class QGraphViz_Core(QWidget):
                     width+=self.engine.margins[0]
                     height+self.engine.margins[1]
                     painter.drawText(
-                        gpos[0]-width/2,
-                        gpos[1]-height/2,
+                        int(gpos[0]-width/2),
+                        int(gpos[1]-height/2),
                         width, height,
                         Qt.AlignCenter|Qt.AlignTop,node.kwargs["label"])
             else:


### PR DESCRIPTION
Fixed problems with float values. PyQt in my programm don’t cast float to int so I added hard casting.
In my programm I set size of node while creating and I have problem that the sizes are changed when I clicked on node. I disabled changing size for label if size is set in kwargs. I hope this changes have sense for you.